### PR TITLE
fix: changed ShAlert component to one used in Nuxt 2 site

### DIFF
--- a/components/ShAlert.vue
+++ b/components/ShAlert.vue
@@ -1,41 +1,31 @@
 <template>
-  <div class="mx-0 p-2">
-    <UAlert
-      :title="title"
-      :description="description"
-      :type="type"
-      :icon="getIconAndColor().icon"
-      :color="getIconAndColor().color"
-      variant="soft"
-    />
+  <div :class="alertClasses">
+    <slot></slot>
   </div>
 </template>
 
-<script setup>
-
-const props = defineProps({
-  title: String,
-  description: String,
-  type: {
-    type: String, // Make sure type is expected as a string
-    default: 'info', // Set a default type if needed
+<script>
+export default {
+  props: {
+    type: {
+      type: String,
+      default: 'info',
+      validator: (value) => ['info', 'success', 'warning', 'danger'].includes(value)
+    }
   },
-  color: String
-});
-
-const getIconAndColor = () => {
-  const typeInfo = {
-    info: { icon: "i-heroicons-information-circle", color: "blue" },
-    success: { icon: "i-heroicons-check-circle", color: "emerald" },
-    warning: { icon: "i-heroicons-exclamation-circle", color: "yellow" },
-    danger: { icon: "i-heroicons-x-circle", color: "red" },
-    wrongType: { icon: "i-heroicons-question-mark-circle", color: "white"},
-  };
-
-  if (typeInfo[props.type]) {
-    return { icon: typeInfo[props.type].icon, color: typeInfo[props.type].color };
-  } else {
-    return { icon: typeInfo.wrongType.icon, color: typeInfo.wrongType.color};
+  computed: {
+    alertClasses() {
+      switch (this.type) {
+        case 'success':
+          return 'bg-[#F0FFF4] dark:bg-[#22543D] text-[#2F855A] dark:text-[#9AE6A9] px-4 py-3 relative border-l-4 border-[#2F855A]';
+        case 'warning':
+          return 'bg-[#FFFAF0] dark:bg-[#744210] text-[#C66328] dark:text-[#FBD375] px-4 py-3 relative border-l-4 border-[#B7791F]';
+        case 'danger':
+          return 'bg-[#FFF5F5] dark:bg-[#742A2A] text-[#D03030] dark:text-[#FEB2B2] px-4 py-3 relative border-l-4 border-[#C53030]';
+        default: // info
+          return 'bg-[#EBF8FF] dark:bg-[#2A4365] text-[#63B3ED] dark:text-[#86CDF4] px-4 py-3 relative border-l-4 border-[#2B6CB0]';
+      }
+    }
   }
 };
 </script>

--- a/components/ShAlert.vue
+++ b/components/ShAlert.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="alertClasses">
+  <div class="flex items-center space-x-1" :class="alertClasses">
+    <div class="flex items-center mx-2">
+      <i :class="iconClass" class="size-6"></i>
+    </div>
     <slot></slot>
   </div>
 </template>
@@ -9,23 +12,36 @@ export default {
   props: {
     type: {
       type: String,
-      default: 'info',
-      validator: (value) => ['info', 'success', 'warning', 'danger'].includes(value)
-    }
+      default: "info",
+      validator: (value) =>
+        ["info", "success", "warning", "danger"].includes(value),
+    },
   },
   computed: {
     alertClasses() {
       switch (this.type) {
-        case 'success':
-          return 'bg-[#F0FFF4] dark:bg-[#22543D] text-[#2F855A] dark:text-[#9AE6A9] px-4 py-3 relative border-l-4 border-[#2F855A]';
-        case 'warning':
-          return 'bg-[#FFFAF0] dark:bg-[#744210] text-[#C66328] dark:text-[#FBD375] px-4 py-3 relative border-l-4 border-[#B7791F]';
-        case 'danger':
-          return 'bg-[#FFF5F5] dark:bg-[#742A2A] text-[#D03030] dark:text-[#FEB2B2] px-4 py-3 relative border-l-4 border-[#C53030]';
+        case "success":
+          return "bg-[#F0FFF4] dark:bg-[#22543D] text-[#2F855A] dark:text-[#9AE6A9] px-2 py-3 relative border-l-4 border-[#2F855A]";
+        case "warning":
+          return "bg-[#FFFAF0] dark:bg-[#744210] text-[#C66328] dark:text-[#FBD375] px-2 py-3 relative border-l-4 border-[#B7791F]";
+        case "danger":
+          return "bg-[#FFF5F5] dark:bg-[#742A2A] text-[#D03030] dark:text-[#FEB2B2] px-2 py-3 relative border-l-4 border-[#C53030]";
         default: // info
-          return 'bg-[#EBF8FF] dark:bg-[#2A4365] text-[#63B3ED] dark:text-[#86CDF4] px-4 py-3 relative border-l-4 border-[#2B6CB0]';
+          return "bg-[#EBF8FF] dark:bg-[#2A4365] text-[#63B3ED] dark:text-[#86CDF4] px-2 py-3 relative border-l-4 border-[#2B6CB0]";
       }
-    }
-  }
+    },
+    iconClass() {
+      switch (this.type) {
+        case "success":
+          return "text-[#2F855A] dark:text-[#9AE6A9] i-heroicons-check-circle";
+        case "warning":
+          return "text-[#C66328] dark:text-[#FBD375] i-heroicons-exclamation-circle";
+        case "danger":
+          return "text-[#D03030] dark:text-[#FEB2B2] i-heroicons-x-circle";
+        default: // info
+          return "text-[#63B3ED] dark:text-[#86CDF4] i-heroicons-information-circle";
+      }
+    },
+  },
 };
 </script>

--- a/content/1.getting-started/1.index.md
+++ b/content/1.getting-started/1.index.md
@@ -29,8 +29,13 @@ export default defineNuxtConfig({
 })
 ```
 
-<ShAlert type="success" title="My title and description" description=" Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus tempus commodo eros. In lacinia lobortis enim ut sollicitudin. Maecenas in velit nisi. Aliquam condimentum magna sed nunc cursus, sed finibus libero laoreet. Aenean eget ante eu libero dapibus iaculis a non mauris. Vivamus nunc ligula, auctor eget varius viverra, fringilla eu diam. Fusce est erat, luctus eget posuere quis, ultricies vitae nisi. Sed porttitor nibh ac dapibus volutpat. Donec a felis nunc. Proin fringilla, quam et viverra suscipit, dui lacus gravida metus, et malesuada tortor lectus eget sem. Suspendisse volutpat eu est in porttitor. Morbi blandit nulla non interdum posuere.  
-Donec interdum mollis neque non aliquam. Nullam fringilla mattis turpis at vulputate. Fusce vehicula dapibus nisi, vel malesuada mauris venenatis viverra. In in leo augue. Nam posuere felis nisi, iaculis dapibus odio auctor sit amet. Nam at augue in arcu ultricies convallis. Sed vitae suscipit orci, a lacinia libero. Nunc ullamcorper purus id felis pharetra faucibus. Aliquam tincidunt dictum faucibus. In eu facilisis arcu. Suspendisse pellentesque mattis suscipit. Duis facilisis eros ut nibh porta eleifend. Nunc vel diam at lectus blandit posuere. Etiam magna nulla, porta suscipit euismod ut, vulputate tincidunt nisl. "></ShAlert>
+<ShAlert>Check out an info alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
+<br/>
+<ShAlert type="success">Check out an success alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
+<br/>
+<ShAlert type="warning">Check out an warning alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
+<br/>
+<ShAlert type="danger">Check out an danger alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
 
 <ShVideo src="/videos/Joaquin Prado - OMNA Objects and Resources Registry.mp4"></ShVideo>
 <ShVideo src="https://www.youtube.com/watch?v=8A5AMiskxvQ"></ShVideo>

--- a/content/1.getting-started/1.index.md
+++ b/content/1.getting-started/1.index.md
@@ -31,11 +31,11 @@ export default defineNuxtConfig({
 
 <ShAlert>Check out an info alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
 <br/>
-<ShAlert type="success">Check out an success alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
+<ShAlert type="success">Check out a success alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
 <br/>
-<ShAlert type="warning">Check out an warning alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
+<ShAlert type="warning">Check out a warning alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
 <br/>
-<ShAlert type="danger">Check out an danger alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
+<ShAlert type="danger">Check out a danger alert with a `codeblock` and a [link](/markdown-guidelines/introduction/)!</ShAlert>
 
 <ShVideo src="/videos/Joaquin Prado - OMNA Objects and Resources Registry.mp4"></ShVideo>
 <ShVideo src="https://www.youtube.com/watch?v=8A5AMiskxvQ"></ShVideo>


### PR DESCRIPTION
Component ShAlert is now made to behave exactly like it did in Nuxt 2 version of site [Markdown_constructors/Alert](https://standards-hub.github.io/markdown_constructors/#alert).
One issue that persist is that codeblock is not getting the right color of the alert, it rather changes only from white to dark depending on the active theme.